### PR TITLE
update i2c read/write sufficiently to get the i2c example working for STM32F042

### DIFF
--- a/arch/stm32/cpp/core/include/i2c.h
+++ b/arch/stm32/cpp/core/include/i2c.h
@@ -53,6 +53,7 @@ public:
 	static bool sendToSlave(I2C_devices device, uint8_t* data, uint8_t len);
 	static bool sendToMaster(I2C_devices device, uint8_t* data, uint8_t len);
 	static bool receiveFromSlave(I2C_devices device, uint32_t count, uint8_t* buffer);
+    static bool receiveFromSlave(I2C_devices device, uint8_t len);
 	static bool receiveFromMaster(I2C_devices device, uint32_t count, uint8_t* buffer);
 	static bool stop(I2C_devices device);
 };

--- a/arch/stm32/cpp/libs/bme280/bme280.cpp
+++ b/arch/stm32/cpp/libs/bme280/bme280.cpp
@@ -38,10 +38,15 @@ bool BME280::readID(uint8_t &id) {
 	uint8_t data = 0xd0;
 	I2C::sendToSlave(device, &data, 1);
 	I2C_wait = true;
+    
+    // Initiate the read sequence
+    if (!(I2C::receiveFromSlave(device,1))) {
+        return false;
+    }
 	
 	// Read the response once it comes in.
 	uint32_t to = 1000000;
-	while (I2C_wait || to < 1) {
+	while (I2C_wait && to > 1) {
 		// TODO: elegantly handle timeout.
 		to--;
 	}

--- a/examples/stm32/i2c_bme280/src/i2c_bme280.cpp
+++ b/examples/stm32/i2c_bme280/src/i2c_bme280.cpp
@@ -56,7 +56,9 @@ int main () {
 	USART::sendUart(USART_1, ch);
 	
 	// Create BME280 sensor instance, on the first I2C bus, slave address 0x76 (default).
-	BME280 sensor(I2C_1, 0x76);
+    // Note that, depending on the design of the BME280 carrier board (if any), the
+    //      slave address may default to 0x76 or 0x77.
+	BME280 sensor(I2C_1, 0x77);
 	if (!sensor.isReady()) {
 		ch = 'f';
 		USART::sendUart(USART_1, ch);
@@ -76,8 +78,8 @@ int main () {
 		ch = 't';
 		GPIO::write(led_port, led_pin, GPIO_LEVEL_HIGH);
 		//printf("Sensor ID: %d\n", id);
-		
-		if (id == 0x76) {
+
+		if (id == 0x60) {
 			ch = 'm';
 		}
 	}


### PR DESCRIPTION
With these changes the i2c_bme289 example works with an STM32F042.  I added a new I2C::receiveFromSlave method to be compatible with your use of interrupts.  I'm not sure, in the future, if that is cleaner than using polling for "read" events initiated by the master.  Just beginning to digest your latest Hackaday article. 

A future issue may be the need to address multiple slaves on a single bus - it may require separating the bus configuration from the slave configuration.