### PR TITLE
bme280 patches

### DIFF
--- a/arch/stm32/cpp/core/src/i2c.cpp
+++ b/arch/stm32/cpp/core/src/i2c.cpp
@@ -482,7 +482,7 @@ bool I2C::sendToMaster(I2C_devices device, uint8_t* data, uint8_t len) {
 bool I2C::receiveFromSlave(I2C_devices device, uint32_t count, uint8_t* buffer) {
 	I2C_device &instance = i2cList[device];
     uint32_t timeOut = (uint32_t) 0x1000;
-#if defined STM32F0 || defined STM32F7
+#if defined STM32F0 
     /* Disable interrupt. An active interrupt handler that reads the RXDR register field will automatically
        reset the RXNE flag, preventing this routine from being notified that data is ready in the data register.
     */

--- a/arch/stm32/cpp/core/src/i2c.cpp
+++ b/arch/stm32/cpp/core/src/i2c.cpp
@@ -481,15 +481,30 @@ bool I2C::sendToMaster(I2C_devices device, uint8_t* data, uint8_t len) {
 // Configure Master to receive data from a Slave device.
 bool I2C::receiveFromSlave(I2C_devices device, uint32_t count, uint8_t* buffer) {
 	I2C_device &instance = i2cList[device];
-#if defined STM32F0
-    instance.regs->CR2 =  I2C_CR2_AUTOEND | (count << 16) | (instance.slaveTarget << 1) | (I2C_CR2_START);
+    uint32_t timeOut = (uint32_t) 0x1000;
+#if defined STM32F0 || defined STM32F7
+    /* Disable interrupt. An active interrupt handler that reads the RXDR register field will automatically
+       reset the RXNE flag, preventing this routine from being notified that data is ready in the data register.
+    */
+    NVIC_DisableIRQ(instance.irqType);
+    
+    while ((instance.regs->ISR & I2C_ISR_BUSY) == I2C_ISR_BUSY) {  // wait for the bus to become "unbusy"
+        if ((timeOut--) == 0) { return false; }
+    }
+
+    instance.regs->CR2 =  I2C_CR2_RD_WRN | I2C_CR2_AUTOEND | (count << 16) | (instance.slaveTarget << 1) | (I2C_CR2_START);
 	
 	for (uint8_t i = 0; i < count; ++i) {
-		// 1. Check ISR_RXNE == 1. (Receive data register Not Empty).
-		if ((instance.regs->ISR & I2C_ISR_RXNE) == I2C_ISR_RXNE) {
-			// 2. Read RXDR into buffer.
-			buffer[i] = (uint8_t) instance.regs->RXDR;
-		}
+        timeOut = (uint32_t) 0x1000;
+        // 1. Check ISR_RXNE == 1. (Receive data register Not Empty).
+        while ((instance.regs->ISR & I2C_ISR_RXNE) != I2C_ISR_RXNE) {
+            if ((timeOut--) == 0) { return false; }
+            if (((instance.regs->ISR & I2C_ISR_BERR) == I2C_ISR_BERR) || ((instance.regs->ISR & I2C_ISR_ARLO) == I2C_ISR_ARLO)) {
+                return false;  // dumpster fire has occurred
+            }
+        }
+        // 2. Read RXDR into buffer.
+		buffer[i] = (uint8_t) instance.regs->RXDR;
 	}
 	
 	// 3. If ISR_TC == 1, we're done. (Transfer Complete).
@@ -498,6 +513,8 @@ bool I2C::receiveFromSlave(I2C_devices device, uint32_t count, uint8_t* buffer) 
 	if ((instance.regs->ISR & I2C_ISR_TC) == I2C_ISR_TC) {
 		// TODO: restart session.
 	}
+    // Re-enable interrupt.
+    NVIC_EnableIRQ(instance.irqType);
 #endif
 	
 	return true;

--- a/arch/stm32/cpp/libs/bme280/bme280.cpp
+++ b/arch/stm32/cpp/libs/bme280/bme280.cpp
@@ -123,7 +123,7 @@ bool BME280::initialize() {
 
 bool BME280::softReset() {
 	uint8_t data[] = { reg_SoftReset, softResetInstruction };
-	I2C::sendToSlave(device, data, 1);
+	I2C::sendToSlave(device, data, 2);
 	
 	return true;
 }

--- a/arch/stm32/cpp/libs/bme280/bme280.cpp
+++ b/arch/stm32/cpp/libs/bme280/bme280.cpp
@@ -77,26 +77,26 @@ bool BME280::initialize() {
 	if (!I2C::sendToSlave(device, data, 2)) { return false; }
 
 	I2C::sendToSlave(device, &reg_CalibrationTStart, 1);
-	uint8_t buffer[64];
+	uint8_t buffer[64] = {0};
 	I2C::receiveFromSlave(device, reg_CalibrationTEnd - reg_CalibrationTStart + 1, buffer);
 	
 	// This data is in Big Endian format from the BME280.
-    dig_T1 = (buffer[1] << 8) | buffer[0];
-    dig_T2 = (buffer[3] << 8) | buffer[2];
-    dig_T3 = (buffer[5] << 8) | buffer[4];
+    dig_T1 = ((uint16_t)buffer[1] << 8) | (uint16_t)buffer[0];
+    dig_T2 = (int16_t)(((uint16_t)buffer[3] << 8) | (uint16_t)buffer[2]);
+    dig_T3 = (int16_t)(((uint16_t)buffer[5] << 8) | (uint16_t)buffer[4]);
 
 	I2C::sendToSlave(device, &reg_CalibrationPStart, 1);
 	I2C::receiveFromSlave(device, reg_CalibrationPEnd - reg_CalibrationPStart + 1, buffer);
 
-    dig_P1 = (buffer[1] << 8) | buffer[0];
-    dig_P2 = (buffer[3] << 8) | buffer[2];
-    dig_P3 = (buffer[5] << 8) | buffer[4];
-    dig_P4 = (buffer[7] << 8) | buffer[6];
-    dig_P5 = (buffer[9] << 8) | buffer[8];
-    dig_P6 = (buffer[11] << 8) | buffer[10];
-    dig_P7 = (buffer[13] << 8) | buffer[12];
-    dig_P8 = (buffer[15] << 8) | buffer[14];
-	dig_P9 = (buffer[17] << 8) | buffer[16];
+    dig_P1 = ((uint16_t)buffer[1] << 8) | (uint16_t)buffer[0];
+    dig_P2 = (int16_t)(((uint16_t)buffer[3] << 8) | (uint16_t)buffer[2]);
+    dig_P3 = (int16_t)(((uint16_t)buffer[5] << 8) | (uint16_t)buffer[4]);
+    dig_P4 = (int16_t)(((uint16_t)buffer[7] << 8) | (uint16_t)buffer[6]);
+    dig_P5 = (int16_t)(((uint16_t)buffer[9] << 8) | (uint16_t)buffer[8]);
+    dig_P6 = (int16_t)(((uint16_t)buffer[11] << 8) | (uint16_t)buffer[10]);
+    dig_P7 = (int16_t)(((uint16_t)buffer[13] << 8) | (uint16_t)buffer[12]);
+    dig_P8 = (int16_t)(((uint16_t)buffer[15] << 8) | (uint16_t)buffer[14]);
+	dig_P9 = (int16_t)(((uint16_t)buffer[17] << 8) | (uint16_t)buffer[16]);
 
 	I2C::sendToSlave(device, &reg_H1, 1);
 	I2C::receiveFromSlave(device, 1, buffer);
@@ -104,7 +104,7 @@ bool BME280::initialize() {
 	
 	I2C::sendToSlave(device, &reg_H2, 1);
 	I2C::receiveFromSlave(device, 2, buffer);
-    dig_H2 = (buffer[1] << 8) | buffer[0];
+    dig_H2 = (int16_t) (((uint16_t)buffer[1] << 8) | (uint16_t)buffer[0]);
 	
 	I2C::sendToSlave(device, &reg_H3, 1);
 	I2C::receiveFromSlave(device, 1, buffer);
@@ -112,10 +112,10 @@ bool BME280::initialize() {
 	
 	I2C::sendToSlave(device, &reg_H4, 1);
 	I2C::receiveFromSlave(device, 4, buffer);
-    dig_H4 = (buffer[0] << 4) | (buffer[1]&0x0F);
+    dig_H4 = (int16_t) ((buffer[0] << 4) | (buffer[1]&0x0F));
 	
-    dig_H5 = (buffer[2]<<4) | ((buffer[1] & 0xF0)>>4);
-	dig_H6 = buffer[3];
+    dig_H5 = (int16_t) ((buffer[2]<<4) | ((buffer[1] & 0xF0)>>4));
+	dig_H6 = (int8_t) buffer[3];
 	
 	return true;
 }

--- a/arch/stm32/cpp/libs/bme280/bme280.cpp
+++ b/arch/stm32/cpp/libs/bme280/bme280.cpp
@@ -77,7 +77,7 @@ bool BME280::initialize() {
 	if (!I2C::sendToSlave(device, data, 2)) { return false; }
 
 	I2C::sendToSlave(device, &reg_CalibrationTStart, 1);
-	uint8_t buffer[64] = {0};
+	uint8_t buffer[64];
 	I2C::receiveFromSlave(device, reg_CalibrationTEnd - reg_CalibrationTStart + 1, buffer);
 	
 	// This data is in Big Endian format from the BME280.

--- a/arch/stm32/cpp/libs/bme280/bme280.cpp
+++ b/arch/stm32/cpp/libs/bme280/bme280.cpp
@@ -81,22 +81,22 @@ bool BME280::initialize() {
 	I2C::receiveFromSlave(device, reg_CalibrationTEnd - reg_CalibrationTStart + 1, buffer);
 	
 	// This data is in Big Endian format from the BME280.
-    dig_T1 = ((uint16_t)buffer[1] << 8) | (uint16_t)buffer[0];
-    dig_T2 = (int16_t)(((uint16_t)buffer[3] << 8) | (uint16_t)buffer[2]);
-    dig_T3 = (int16_t)(((uint16_t)buffer[5] << 8) | (uint16_t)buffer[4]);
+    dig_T1 = (buffer[1] << 8) | buffer[0];
+    dig_T2 = (buffer[3] << 8) | buffer[2];
+    dig_T3 = (buffer[5] << 8) | buffer[4];
 
 	I2C::sendToSlave(device, &reg_CalibrationPStart, 1);
 	I2C::receiveFromSlave(device, reg_CalibrationPEnd - reg_CalibrationPStart + 1, buffer);
 
-    dig_P1 = ((uint16_t)buffer[1] << 8) | (uint16_t)buffer[0];
-    dig_P2 = (int16_t)(((uint16_t)buffer[3] << 8) | (uint16_t)buffer[2]);
-    dig_P3 = (int16_t)(((uint16_t)buffer[5] << 8) | (uint16_t)buffer[4]);
-    dig_P4 = (int16_t)(((uint16_t)buffer[7] << 8) | (uint16_t)buffer[6]);
-    dig_P5 = (int16_t)(((uint16_t)buffer[9] << 8) | (uint16_t)buffer[8]);
-    dig_P6 = (int16_t)(((uint16_t)buffer[11] << 8) | (uint16_t)buffer[10]);
-    dig_P7 = (int16_t)(((uint16_t)buffer[13] << 8) | (uint16_t)buffer[12]);
-    dig_P8 = (int16_t)(((uint16_t)buffer[15] << 8) | (uint16_t)buffer[14]);
-	dig_P9 = (int16_t)(((uint16_t)buffer[17] << 8) | (uint16_t)buffer[16]);
+    dig_P1 = (buffer[1] << 8) | buffer[0];
+    dig_P2 = (buffer[3] << 8) | buffer[2];
+    dig_P3 = (buffer[5] << 8) | buffer[4];
+    dig_P4 = (buffer[7] << 8) | buffer[6];
+    dig_P5 = (buffer[9] << 8) | buffer[8];
+    dig_P6 = (buffer[11] << 8) | buffer[10];
+    dig_P7 = (buffer[13] << 8) | buffer[12];
+    dig_P8 = (buffer[15] << 8) | buffer[14];
+	dig_P9 = (buffer[17] << 8) | buffer[16];
 
 	I2C::sendToSlave(device, &reg_H1, 1);
 	I2C::receiveFromSlave(device, 1, buffer);
@@ -104,7 +104,7 @@ bool BME280::initialize() {
 	
 	I2C::sendToSlave(device, &reg_H2, 1);
 	I2C::receiveFromSlave(device, 2, buffer);
-    dig_H2 = (int16_t) (((uint16_t)buffer[1] << 8) | (uint16_t)buffer[0]);
+    dig_H2 = (buffer[1] << 8) | buffer[0];
 	
 	I2C::sendToSlave(device, &reg_H3, 1);
 	I2C::receiveFromSlave(device, 1, buffer);
@@ -112,10 +112,10 @@ bool BME280::initialize() {
 	
 	I2C::sendToSlave(device, &reg_H4, 1);
 	I2C::receiveFromSlave(device, 4, buffer);
-    dig_H4 = (int16_t) ((buffer[0] << 4) | (buffer[1]&0x0F));
+    dig_H4 = (buffer[0] << 4) | (buffer[1]&0x0F);
 	
-    dig_H5 = (int16_t) ((buffer[2]<<4) | ((buffer[1] & 0xF0)>>4));
-	dig_H6 = (int8_t) buffer[3];
+    dig_H5 = (buffer[2]<<4) | ((buffer[1] & 0xF0)>>4);
+	dig_H6 = buffer[3];
 	
 	return true;
 }


### PR DESCRIPTION
This pull request addresses a couple of difficulties I had getting the bme280 example to work.

- The BME280::softReset() method is modified to transmit both entries in the data array, activating the soft reset.
- The I2C::receiveFromSlave() method is modified to incorporate these changes:

1. If the interrupt handler is active, it is turned off until the required number of values are read into the buffer.  An active interrupt handler reads the RXDR register, which results in immediately clearing the RXNE flag and preventing this routine from recognizing incoming data.
2. The I2C_CR2_RD_WRN bit is now set in the CR2 register, resulting in a receive action rather than a transmit action.
3. The For loop that checked for ISR_RXNE was restructured to accommodate a slow I2C clock.