### PR TITLE
Rcc::configureSysClock() modifications

### DIFF
--- a/arch/stm32/cpp/core/src/rcc.cpp
+++ b/arch/stm32/cpp/core/src/rcc.cpp
@@ -723,30 +723,49 @@ bool getAHBprescaler(uint32_t divisor, uint32_t &AHBfield) {
 }
 
 bool getAPB1prescaler(uint32_t divisor, uint32_t &APB1field) {
+#if defined __stm32f0
+    uint32_t bitFields[5] = {
+        RCC_CFGR_PPRE_DIV1,
+        RCC_CFGR_PPRE_DIV2,
+        RCC_CFGR_PPRE_DIV4,
+        RCC_CFGR_PPRE_DIV8,
+        RCC_CFGR_PPRE_DIV16 };
+#else
+    uint32_t bitFields[5] = {
+        RCC_CFGR_PPRE1_DIV1,
+        RCC_CFGR_PPRE1_DIV2,
+        RCC_CFGR_PPRE1_DIV4,
+        RCC_CFGR_PPRE1_DIV8,
+        RCC_CFGR_PPRE1_DIV16 };
+#endif
     switch(divisor) {
         case 1:
-            APB1field = RCC_CFGR_PPRE1_DIV1;
+            APB1field = bitFields[0];
             break;
         case 2:
-            APB1field = RCC_CFGR_PPRE1_DIV2;
+            APB1field = bitFields[1];
             break;
         case 4:
-            APB1field = RCC_CFGR_PPRE1_DIV4;
+            APB1field = bitFields[2];
             break;
         case 8:
-            APB1field = RCC_CFGR_PPRE1_DIV8;
+            APB1field = bitFields[3];
             break;
         case 16:
-            APB1field = RCC_CFGR_PPRE1_DIV16;
+            APB1field = bitFields[4];
             break;
         default:
-            APB1field = RCC_CFGR_PPRE1_DIV1;
+            APB1field = bitFields[1];
             return false;
     }
     return true;
 }
 
 bool getAPB2prescaler(uint32_t divisor, uint32_t &APB2field) {
+#if defined __stm32f0
+    APB2field = 0;  //APB2 doesn't exist for STM32F0
+    return false;
+#else
     switch(divisor) {
         case 1:
             APB2field = RCC_CFGR_PPRE2_DIV1;
@@ -767,6 +786,7 @@ bool getAPB2prescaler(uint32_t divisor, uint32_t &APB2field) {
             APB2field = RCC_CFGR_PPRE2_DIV1;
             return false;
     }
+#endif
     return true;
 }
 

--- a/arch/stm32/cpp/core/src/rcc.cpp
+++ b/arch/stm32/cpp/core/src/rcc.cpp
@@ -629,6 +629,9 @@ bool Rcc::configureSysClock(RccSysClockConfig cfg) {
 		RCC->CR &= ~RCC_CR_HSEON;
 		if (cfg.HSE_bypass) { RCC->CR |= RCC_CR_HSEBYP;	}
 		else 				{ RCC->CR &= ~RCC_CR_HSEBYP; }
+        RCC->CR |= RCC_CR_HSEON;
+        // Wait for HSE to stabilise.
+        while (!(RCC->CR & (uint32_t) RCC_CR_HSERDY)) { }
 	}
 	else {
 		return false;
@@ -641,16 +644,20 @@ bool Rcc::configureSysClock(RccSysClockConfig cfg) {
 	RCC->PLLCFGR |= ((uint32_t) cfg.PLL_source << RCC_PLLCFGR_PLLSRC_Pos);
 	
 	if (cfg.PLLM > 63 || cfg.PLLM == 0 || cfg.PLLM == 1) { return false; }
+    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLM;
 	RCC->PLLCFGR |= (cfg.PLLM << RCC_PLLCFGR_PLLM_Pos);
 	
 	if (cfg.PLLN > 432 || cfg.PLLN == 0 || cfg.PLLN == 1) { return false; }
+    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLN;
 	RCC->PLLCFGR |= (cfg.PLLN << RCC_PLLCFGR_PLLN_Pos);
 	
 	if (cfg.PLLP != 2 && cfg.PLLP != 4 && cfg.PLLP != 6 && cfg.PLLP != 8) { return false; }
 	uint32_t new_pllp = (cfg.PLLP / 2) - 1;
+    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLP;
 	RCC->PLLCFGR |= (new_pllp << RCC_PLLCFGR_PLLP_Pos);
 	
-	if (cfg.PLLQ > 15 || cfg.PLLM == 0 || cfg.PLLM == 1) { return false; }
+	if (cfg.PLLQ > 15 || cfg.PLLQ == 0 || cfg.PLLQ == 1) { return false; }
+    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLQ;
 	RCC->PLLCFGR |= (cfg.PLLQ << RCC_PLLCFGR_PLLQ_Pos);
 	
 	// Enable PLL.

--- a/arch/stm32/cpp/core/src/rcc.cpp
+++ b/arch/stm32/cpp/core/src/rcc.cpp
@@ -16,6 +16,9 @@ static const uint8_t handle_max = std::numeric_limits<uint8_t>::max();
 
 const int portCount = 11;
 const int peripheralCount = 41;
+bool getAHBprescaler(uint32_t divisor, uint32_t &AHBfield);
+bool getAPB1prescaler(uint32_t divisor, uint32_t &APB1field);
+bool getAPB2prescaler(uint32_t divisor, uint32_t &APB2field);
 
 // Private methods:
 
@@ -590,9 +593,15 @@ bool Rcc::disablePort(RccPort port) {
 bool Rcc::configureSysClock(RccSysClockConfig cfg) {
 #ifdef __stm32f7
 	// Set AHB & APB dividers.
-	RCC->CFGR |= (cfg.AHB_prescale << RCC_CFGR_HPRE_Pos);
-	RCC->CFGR |= (cfg.APB1_prescale << RCC_CFGR_PPRE1_Pos);
-	RCC->CFGR |= (cfg.APB2_prescale << RCC_CFGR_PPRE2_Pos);
+    uint32_t bitField;
+    if (!getAHBprescaler(cfg.AHB_prescale, bitField)) {return false;}
+    RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_HPRE) | bitField;
+    
+    if (!getAPB1prescaler(cfg.APB1_prescale, bitField)) {return false;}
+    RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE1) | bitField;
+    
+    if (!getAPB2prescaler(cfg.APB2_prescale, bitField)) {return false;}
+    RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE2) | bitField;
 	
 	if (cfg.source == (uint32_t) RCC_SYSCLOCK_SRC_HSE) {
 		// HSE oscillator is used with external crystal. 
@@ -669,3 +678,88 @@ bool Rcc::enableLSE(bool on) {
 	
 	return true;
 }
+
+bool getAHBprescaler(uint32_t divisor, uint32_t &AHBfield) {
+    switch(divisor) {
+        case 1:
+            AHBfield = RCC_CFGR_HPRE_DIV1;
+            break;
+        case 2:
+            AHBfield = RCC_CFGR_HPRE_DIV2;
+            break;
+        case 4:
+            AHBfield = RCC_CFGR_HPRE_DIV4;
+            break;
+        case 8:
+            AHBfield = RCC_CFGR_HPRE_DIV8;
+            break;
+        case 16:
+            AHBfield = RCC_CFGR_HPRE_DIV16;
+            break;
+        case 64:
+            AHBfield = RCC_CFGR_HPRE_DIV64;
+            break;
+        case 128:
+            AHBfield = RCC_CFGR_HPRE_DIV128;
+            break;
+        case 256:
+            AHBfield = RCC_CFGR_HPRE_DIV256;
+            break;
+        case 512:
+            AHBfield = RCC_CFGR_HPRE_DIV512;
+            break;
+        default:
+            AHBfield = RCC_CFGR_HPRE_DIV1;
+            return false;
+    }
+    return true;
+}
+
+bool getAPB1prescaler(uint32_t divisor, uint32_t &APB1field) {
+    switch(divisor) {
+        case 1:
+            APB1field = RCC_CFGR_PPRE1_DIV1;
+            break;
+        case 2:
+            APB1field = RCC_CFGR_PPRE1_DIV2;
+            break;
+        case 4:
+            APB1field = RCC_CFGR_PPRE1_DIV4;
+            break;
+        case 8:
+            APB1field = RCC_CFGR_PPRE1_DIV8;
+            break;
+        case 16:
+            APB1field = RCC_CFGR_PPRE1_DIV16;
+            break;
+        default:
+            APB1field = RCC_CFGR_PPRE1_DIV1;
+            return false;
+    }
+    return true;
+}
+
+bool getAPB2prescaler(uint32_t divisor, uint32_t &APB2field) {
+    switch(divisor) {
+        case 1:
+            APB2field = RCC_CFGR_PPRE2_DIV1;
+            break;
+        case 2:
+            APB2field = RCC_CFGR_PPRE2_DIV2;
+            break;
+        case 4:
+            APB2field = RCC_CFGR_PPRE2_DIV4;
+            break;
+        case 8:
+            APB2field = RCC_CFGR_PPRE2_DIV8;
+            break;
+        case 16:
+            APB2field = RCC_CFGR_PPRE2_DIV16;
+            break;
+        default:
+            APB2field = RCC_CFGR_PPRE2_DIV1;
+            return false;
+    }
+    return true;
+}
+

--- a/arch/stm32/cpp/core/src/rcc.cpp
+++ b/arch/stm32/cpp/core/src/rcc.cpp
@@ -646,7 +646,7 @@ bool Rcc::configureSysClock(RccSysClockConfig cfg) {
 	if (cfg.PLLN > 432 || cfg.PLLN == 0 || cfg.PLLN == 1) { return false; }
 	RCC->PLLCFGR |= (cfg.PLLN << RCC_PLLCFGR_PLLN_Pos);
 	
-	if (cfg.PLLP != 2 || cfg.PLLP != 4 || cfg.PLLP != 6 || cfg.PLLP != 8) { return false; }
+	if (cfg.PLLP != 2 && cfg.PLLP != 4 && cfg.PLLP != 6 && cfg.PLLP != 8) { return false; }
 	uint32_t new_pllp = (cfg.PLLP / 2) - 1;
 	RCC->PLLCFGR |= (new_pllp << RCC_PLLCFGR_PLLP_Pos);
 	

--- a/arch/stm32/cpp/core/src/rcc.cpp
+++ b/arch/stm32/cpp/core/src/rcc.cpp
@@ -593,15 +593,15 @@ bool Rcc::disablePort(RccPort port) {
 bool Rcc::configureSysClock(RccSysClockConfig cfg) {
 #ifdef __stm32f7
 	// Set AHB & APB dividers.
-    uint32_t bitField;
-    if (!getAHBprescaler(cfg.AHB_prescale, bitField)) {return false;}
-    RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_HPRE) | bitField;
-    
-    if (!getAPB1prescaler(cfg.APB1_prescale, bitField)) {return false;}
-    RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE1) | bitField;
-    
-    if (!getAPB2prescaler(cfg.APB2_prescale, bitField)) {return false;}
-    RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE2) | bitField;
+	uint32_t bitField;
+	if (!getAHBprescaler(cfg.AHB_prescale, bitField)) {return false;}
+	RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_HPRE) | bitField;
+	
+	if (!getAPB1prescaler(cfg.APB1_prescale, bitField)) {return false;}
+	RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE1) | bitField;
+	
+	if (!getAPB2prescaler(cfg.APB2_prescale, bitField)) {return false;}
+	RCC->CFGR = (RCC->CFGR & ~RCC_CFGR_PPRE2) | bitField;
 	
 	if (cfg.source == (uint32_t) RCC_SYSCLOCK_SRC_HSE) {
 		// HSE oscillator is used with external crystal. 
@@ -629,9 +629,9 @@ bool Rcc::configureSysClock(RccSysClockConfig cfg) {
 		RCC->CR &= ~RCC_CR_HSEON;
 		if (cfg.HSE_bypass) { RCC->CR |= RCC_CR_HSEBYP;	}
 		else 				{ RCC->CR &= ~RCC_CR_HSEBYP; }
-        RCC->CR |= RCC_CR_HSEON;
-        // Wait for HSE to stabilise.
-        while (!(RCC->CR & (uint32_t) RCC_CR_HSERDY)) { }
+		RCC->CR |= RCC_CR_HSEON;
+		// Wait for HSE to stabilise.
+		while (!(RCC->CR & (uint32_t) RCC_CR_HSERDY)) { }
 	}
 	else {
 		return false;
@@ -644,20 +644,20 @@ bool Rcc::configureSysClock(RccSysClockConfig cfg) {
 	RCC->PLLCFGR |= ((uint32_t) cfg.PLL_source << RCC_PLLCFGR_PLLSRC_Pos);
 	
 	if (cfg.PLLM > 63 || cfg.PLLM == 0 || cfg.PLLM == 1) { return false; }
-    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLM;
+	RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLM;
 	RCC->PLLCFGR |= (cfg.PLLM << RCC_PLLCFGR_PLLM_Pos);
 	
 	if (cfg.PLLN > 432 || cfg.PLLN == 0 || cfg.PLLN == 1) { return false; }
-    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLN;
+	RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLN;
 	RCC->PLLCFGR |= (cfg.PLLN << RCC_PLLCFGR_PLLN_Pos);
 	
 	if (cfg.PLLP != 2 && cfg.PLLP != 4 && cfg.PLLP != 6 && cfg.PLLP != 8) { return false; }
 	uint32_t new_pllp = (cfg.PLLP / 2) - 1;
-    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLP;
+	RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLP;
 	RCC->PLLCFGR |= (new_pllp << RCC_PLLCFGR_PLLP_Pos);
 	
 	if (cfg.PLLQ > 15 || cfg.PLLQ == 0 || cfg.PLLQ == 1) { return false; }
-    RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLQ;
+	RCC->PLLCFGR &= ~RCC_PLLCFGR_PLLQ;
 	RCC->PLLCFGR |= (cfg.PLLQ << RCC_PLLCFGR_PLLQ_Pos);
 	
 	// Enable PLL.
@@ -687,106 +687,106 @@ bool Rcc::enableLSE(bool on) {
 }
 
 bool getAHBprescaler(uint32_t divisor, uint32_t &AHBfield) {
-    switch(divisor) {
-        case 1:
-            AHBfield = RCC_CFGR_HPRE_DIV1;
-            break;
-        case 2:
-            AHBfield = RCC_CFGR_HPRE_DIV2;
-            break;
-        case 4:
-            AHBfield = RCC_CFGR_HPRE_DIV4;
-            break;
-        case 8:
-            AHBfield = RCC_CFGR_HPRE_DIV8;
-            break;
-        case 16:
-            AHBfield = RCC_CFGR_HPRE_DIV16;
-            break;
-        case 64:
-            AHBfield = RCC_CFGR_HPRE_DIV64;
-            break;
-        case 128:
-            AHBfield = RCC_CFGR_HPRE_DIV128;
-            break;
-        case 256:
-            AHBfield = RCC_CFGR_HPRE_DIV256;
-            break;
-        case 512:
-            AHBfield = RCC_CFGR_HPRE_DIV512;
-            break;
-        default:
-            AHBfield = RCC_CFGR_HPRE_DIV1;
-            return false;
-    }
-    return true;
+	switch(divisor) {
+		case 1:
+			AHBfield = RCC_CFGR_HPRE_DIV1;
+			break;
+		case 2:
+			AHBfield = RCC_CFGR_HPRE_DIV2;
+			break;
+		case 4:
+			AHBfield = RCC_CFGR_HPRE_DIV4;
+			break;
+		case 8:
+			AHBfield = RCC_CFGR_HPRE_DIV8;
+			break;
+		case 16:
+			AHBfield = RCC_CFGR_HPRE_DIV16;
+			break;
+		case 64:
+			AHBfield = RCC_CFGR_HPRE_DIV64;
+			break;
+		case 128:
+			AHBfield = RCC_CFGR_HPRE_DIV128;
+			break;
+		case 256:
+			AHBfield = RCC_CFGR_HPRE_DIV256;
+			break;
+		case 512:
+			AHBfield = RCC_CFGR_HPRE_DIV512;
+			break;
+		default:
+			AHBfield = RCC_CFGR_HPRE_DIV1;
+			return false;
+	}
+	return true;
 }
 
 bool getAPB1prescaler(uint32_t divisor, uint32_t &APB1field) {
 #if defined __stm32f0
-    uint32_t bitFields[5] = {
-        RCC_CFGR_PPRE_DIV1,
-        RCC_CFGR_PPRE_DIV2,
-        RCC_CFGR_PPRE_DIV4,
-        RCC_CFGR_PPRE_DIV8,
-        RCC_CFGR_PPRE_DIV16 };
+	uint32_t bitFields[5] = {
+		RCC_CFGR_PPRE_DIV1,
+		RCC_CFGR_PPRE_DIV2,
+		RCC_CFGR_PPRE_DIV4,
+		RCC_CFGR_PPRE_DIV8,
+		RCC_CFGR_PPRE_DIV16 };
 #else
-    uint32_t bitFields[5] = {
-        RCC_CFGR_PPRE1_DIV1,
-        RCC_CFGR_PPRE1_DIV2,
-        RCC_CFGR_PPRE1_DIV4,
-        RCC_CFGR_PPRE1_DIV8,
-        RCC_CFGR_PPRE1_DIV16 };
+	uint32_t bitFields[5] = {
+		RCC_CFGR_PPRE1_DIV1,
+		RCC_CFGR_PPRE1_DIV2,
+		RCC_CFGR_PPRE1_DIV4,
+		RCC_CFGR_PPRE1_DIV8,
+		RCC_CFGR_PPRE1_DIV16 };
 #endif
-    switch(divisor) {
-        case 1:
-            APB1field = bitFields[0];
-            break;
-        case 2:
-            APB1field = bitFields[1];
-            break;
-        case 4:
-            APB1field = bitFields[2];
-            break;
-        case 8:
-            APB1field = bitFields[3];
-            break;
-        case 16:
-            APB1field = bitFields[4];
-            break;
-        default:
-            APB1field = bitFields[1];
-            return false;
-    }
-    return true;
+	switch(divisor) {
+		case 1:
+			APB1field = bitFields[0];
+			break;
+		case 2:
+			APB1field = bitFields[1];
+			break;
+		case 4:
+			APB1field = bitFields[2];
+			break;
+		case 8:
+			APB1field = bitFields[3];
+			break;
+		case 16:
+			APB1field = bitFields[4];
+			break;
+		default:
+			APB1field = bitFields[1];
+			return false;
+	}
+	return true;
 }
 
 bool getAPB2prescaler(uint32_t divisor, uint32_t &APB2field) {
 #if defined __stm32f0
-    APB2field = 0;  //APB2 doesn't exist for STM32F0
-    return false;
+	APB2field = 0;  //APB2 doesn't exist for STM32F0
+	return false;
 #else
-    switch(divisor) {
-        case 1:
-            APB2field = RCC_CFGR_PPRE2_DIV1;
-            break;
-        case 2:
-            APB2field = RCC_CFGR_PPRE2_DIV2;
-            break;
-        case 4:
-            APB2field = RCC_CFGR_PPRE2_DIV4;
-            break;
-        case 8:
-            APB2field = RCC_CFGR_PPRE2_DIV8;
-            break;
-        case 16:
-            APB2field = RCC_CFGR_PPRE2_DIV16;
-            break;
-        default:
-            APB2field = RCC_CFGR_PPRE2_DIV1;
-            return false;
-    }
+	switch(divisor) {
+		case 1:
+			APB2field = RCC_CFGR_PPRE2_DIV1;
+			break;
+		case 2:
+			APB2field = RCC_CFGR_PPRE2_DIV2;
+			break;
+		case 4:
+			APB2field = RCC_CFGR_PPRE2_DIV4;
+			break;
+		case 8:
+			APB2field = RCC_CFGR_PPRE2_DIV8;
+			break;
+		case 16:
+			APB2field = RCC_CFGR_PPRE2_DIV16;
+			break;
+		default:
+			APB2field = RCC_CFGR_PPRE2_DIV1;
+			return false;
+	}
 #endif
-    return true;
+	return true;
 }
 

--- a/arch/stm32/cpp/core/src/usart.cpp
+++ b/arch/stm32/cpp/core/src/usart.cpp
@@ -341,7 +341,7 @@ bool USART::startUart(USART_devices device, GPIO_ports tx_port, uint8_t tx_pin, 
 #if defined STM32F0
     tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE_Msk) >> RCC_CFGR_PPRE_Pos)];
 #else
-    if ((instance.regs == USART1) || (instance.regs == USART6)) {
+    if ((device == USART_1) || (device == USART_6)) {
         tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE2_Msk) >> RCC_CFGR_PPRE2_Pos)];
     }
     else {

--- a/arch/stm32/cpp/core/src/usart.cpp
+++ b/arch/stm32/cpp/core/src/usart.cpp
@@ -335,22 +335,22 @@ bool USART::startUart(USART_devices device, GPIO_ports tx_port, uint8_t tx_pin, 
 	// TODO: adjust for STM32F1.
 	//instance.regs->BRR = SystemCoreClock / baudrate;
 	//uint16_t uartdiv = SystemCoreClock / baudrate;
-    
-    // Retrieve the APBx clock prescaler divisor and determine the PCLKx frequency
-    uint32_t tmp;
+	
+	// Retrieve the APBx clock prescaler divisor and determine the PCLKx frequency
+	uint32_t tmp;
 #if defined STM32F0
-    tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE_Msk) >> RCC_CFGR_PPRE_Pos)];
+	tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE_Msk) >> RCC_CFGR_PPRE_Pos)];
 #else
-    if ((device == USART_1) || (device == USART_6)) {
-        tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE2_Msk) >> RCC_CFGR_PPRE2_Pos)];
-    }
-    else {
-        tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE1_Msk) >> RCC_CFGR_PPRE1_Pos)];
-    }
+	if ((device == USART_1) || (device == USART_6)) {
+		tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE2_Msk) >> RCC_CFGR_PPRE2_Pos)];
+	}
+	else {
+		tmp = APBPrescTable[((RCC->CFGR & RCC_CFGR_PPRE1_Msk) >> RCC_CFGR_PPRE1_Pos)];
+	}
 #endif
-    uint32_t usartClock = SystemCoreClock >> tmp;
-    uint16_t uartdiv = usartClock / baudrate;
-    
+	uint32_t usartClock = SystemCoreClock >> tmp;
+	uint16_t uartdiv = usartClock / baudrate;
+	
 #if defined __stm32f0 || defined __stm32f7
 	instance.regs->BRR = (((uartdiv / 16) << USART_BRR_DIV_MANTISSA_Pos) |
 							((uartdiv % 16) << USART_BRR_DIV_FRACTION_Pos));


### PR DESCRIPTION
This pull requests addresses a few items in `Rcc::configureSysClock()`:

- sets RCC->CFGR bit fields associated with AHB and APB dividers (the bit fields are generally not equal to the dividers)
- turns the HSE clock on in preparation for use by the PLL
- clears the PLL multiplier/divider field defaults prior to loading with new values
- adds three functions that return the AHB and APB divider bit fields.  (The functions feel clunky, but the switch statements are the cleanest approach I could figure out. I'm not sure if there is a smaller, neater method.)