### PR TITLE
Fixes #19: STM32F1 gpio alternate functions not working

### DIFF
--- a/arch/stm32/cpp/core/include/rcc.h
+++ b/arch/stm32/cpp/core/include/rcc.h
@@ -36,6 +36,7 @@ enum RccPeripheral {
 	RCC_AFIO,
 	RCC_TIM2,		// APB1 peripherals
 	RCC_TIM3,
+	RCC_TIM4,
 	RCC_TIM6,
 	RCC_TIM7,
 	RCC_TIM14,

--- a/arch/stm32/cpp/core/src/rcc.cpp
+++ b/arch/stm32/cpp/core/src/rcc.cpp
@@ -15,7 +15,7 @@ static const uint8_t handle_max = std::numeric_limits<uint8_t>::max();
 
 
 const int portCount = 11;
-const int peripheralCount = 41;
+const int peripheralCount = 42;
 bool getAHBprescaler(uint32_t divisor, uint32_t &AHBfield);
 bool getAPB1prescaler(uint32_t divisor, uint32_t &APB1field);
 bool getAPB2prescaler(uint32_t divisor, uint32_t &APB2field);
@@ -338,6 +338,12 @@ RccPeripheralHandle* peripheralHandles() {
 	peripheralHandlesStatic[RCC_TIM3].exists = true;
 	peripheralHandlesStatic[RCC_TIM3].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_TIM3].enable = RCC_APB1ENR_TIM3EN_Pos;
+#endif
+
+#ifdef RCC_APB1ENR_TIM4EN
+	peripheralHandlesStatic[RCC_TIM4].exists = true;
+	peripheralHandlesStatic[RCC_TIM4].enr = &(RCC->APB1ENR);
+	peripheralHandlesStatic[RCC_TIM4].enable = RCC_APB1ENR_TIM4EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_TIM6EN

--- a/arch/stm32/cpp/core/src/usart.cpp
+++ b/arch/stm32/cpp/core/src/usart.cpp
@@ -298,12 +298,15 @@ bool USART::startUart(USART_devices device, GPIO_ports tx_port, uint8_t tx_pin, 
 	
 	// Set AF mode on the specified pins.
 #ifdef __stm32f1
+	// STM32F1 requires setting AF mode in the peripheral register
+	// as well as setting the MODEx1 pin in the CRL or CRH
+	// register, as appropriate
 	if (!gpio.set_af(per, tx_af)) {
 		Rcc::disablePort((RccPort) tx_port);
 		Rcc::disablePort((RccPort) rx_port);
 		return false;
 	}
-#else
+#endif
 	if (!gpio.set_af(tx_port, tx_pin, tx_af)) {
 		Rcc::disablePort((RccPort) tx_port);
 		return false;
@@ -314,7 +317,6 @@ bool USART::startUart(USART_devices device, GPIO_ports tx_port, uint8_t tx_pin, 
 		Rcc::disablePort((RccPort) rx_port);
 		return false;
 	}
-#endif
 		
 	if (!gpio.set_output_parameters(rx_port, rx_pin, GPIO_PULL_UP, GPIO_PUSH_PULL, GPIO_HIGH)) {
 		Rcc::disablePort((RccPort) tx_port);
@@ -391,7 +393,7 @@ bool USART::sendUart(USART_devices device, char &ch) {
 #if defined __stm32f0 || defined __stm32f7
 	while (!(instance.regs->ISR & USART_ISR_TXE)) {};
 	instance.regs->TDR = (uint8_t) ch;
-#elif defined __stm32f4
+#elif defined __stm32f4 || defined __stm32f1
 	while (!(instance.regs->SR & USART_SR_TXE)) {};
 	instance.regs->DR = (uint8_t) ch;
 #endif


### PR DESCRIPTION
changes include:

- updates to gpio.cpp `set_af` methods to support STM32F1 gpio alternate functions
- updates to gpio.cpp `set_af` methods to support 2-bit fields in the AFIO->MAPR register 
- updates to rcc.h and rcc.cpp to fully support optional STM32F1 peripherals
- update to usart.cpp to support use of both `set_af` methods for STM32F1 MCUs