### PR TITLE
Fixes #21 : SystemCoreClock used to determine STM32 I2C timing register

### DIFF
--- a/arch/stm32/cpp/core/src/gpio.cpp
+++ b/arch/stm32/cpp/core/src/gpio.cpp
@@ -19,28 +19,36 @@ GPIO_instance* GPIO_instances() {
 		instancesStatic[i] = instance;
 	}
 	
-#if defined RCC_AHBENR_GPIOAEN || defined RCC_AHB1ENR_GPIOAEN || defined RCC_APB2ENR_IOPAEN
+#if defined RCC_AHBENR_GPIOAEN || defined RCC_AHB1ENR_GPIOAEN || defined RCC_APB2ENR_IOPAEN || RCC_AHB2ENR_GPIOAEN
 	instancesStatic[GPIO_PORT_A].regs = GPIOA;
 #endif
 
-#if defined RCC_AHBENR_GPIOBEN || defined RCC_AHB1ENR_GPIOBEN || defined RCC_APB2ENR_IOPBEN
+#if defined RCC_AHBENR_GPIOBEN || defined RCC_AHB1ENR_GPIOBEN || defined RCC_APB2ENR_IOPBEN || RCC_AHB2ENR_GPIOBEN
 	instancesStatic[GPIO_PORT_B].regs = GPIOB;
 #endif
 
-#if defined RCC_AHBENR_GPIOCEN || defined RCC_AHB1ENR_GPIOCEN || defined RCC_APB2ENR_IOPCEN
+#if defined RCC_AHBENR_GPIOCEN || defined RCC_AHB1ENR_GPIOCEN || defined RCC_APB2ENR_IOPCEN || RCC_AHB2ENR_GPIOCEN
 	instancesStatic[GPIO_PORT_C].regs = GPIOC;
 #endif
 
-#if defined RCC_AHBENR_GPIODEN || defined RCC_AHB1ENR_GPIODEN || defined RCC_APB2ENR_IOPDEN
+#if defined RCC_AHBENR_GPIODEN || defined RCC_AHB1ENR_GPIODEN || defined RCC_APB2ENR_IOPDEN || RCC_AHB2ENR_GPIODEN
 	instancesStatic[GPIO_PORT_D].regs = GPIOD;
 #endif
 
-#if defined RCC_AHBENR_GPIOEEN || defined RCC_AHB1ENR_GPIOEEN || defined RCC_APB2ENR_IOPEEN
+#if defined RCC_AHBENR_GPIOEEN || defined RCC_AHB1ENR_GPIOEEN || defined RCC_APB2ENR_IOPEEN || RCC_AHB2ENR_GPIOEEN
 	instancesStatic[GPIO_PORT_E].regs = GPIOE;
 #endif
 
-#if defined RCC_AHBENR_GPIOFEN || defined RCC_AHB1ENR_GPIOFEN
+#if defined RCC_AHBENR_GPIOFEN || defined RCC_AHB1ENR_GPIOFEN || defined RCC_APB2ENR_IOPFEN  || RCC_AHB2ENR_GPIOFEN
 	instancesStatic[GPIO_PORT_F].regs = GPIOF;
+#endif
+
+#if defined RCC_AHBENR_GPIOGEN || defined RCC_AHB1ENR_GPIOGEN || defined RCC_APB2ENR_IOPGEN  || RCC_AHB2ENR_GPIOGEN
+	instancesStatic[GPIO_PORT_G].regs = GPIOG;
+#endif
+
+#if defined RCC_AHBENR_GPIOHEN || defined RCC_AHB1ENR_GPIOHEN || defined RCC_APB2ENR_IOPHEN  || RCC_AHB2ENR_GPIOHEN
+	instancesStatic[GPIO_PORT_H].regs = GPIOH;
 #endif
 	
 	return instancesStatic;

--- a/arch/stm32/cpp/core/src/rcc.cpp
+++ b/arch/stm32/cpp/core/src/rcc.cpp
@@ -42,6 +42,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_A].exists = true;
 	portHandlesStatic[RCC_PORT_A].enr = &(RCC->APB2ENR);
 	portHandlesStatic[RCC_PORT_A].enable = RCC_APB2ENR_IOPAEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOAEN
+	portHandlesStatic[RCC_PORT_A].exists = true;
+	portHandlesStatic[RCC_PORT_A].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_A].enable = RCC_AHB2ENR_GPIOAEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOBEN
@@ -56,6 +60,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_B].exists = true;
 	portHandlesStatic[RCC_PORT_B].enr = &(RCC->APB2ENR);
 	portHandlesStatic[RCC_PORT_B].enable = RCC_APB2ENR_IOPBEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOBEN
+	portHandlesStatic[RCC_PORT_B].exists = true;
+	portHandlesStatic[RCC_PORT_B].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_B].enable = RCC_AHB2ENR_GPIOBEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOCEN
@@ -70,6 +78,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_C].exists = true;
 	portHandlesStatic[RCC_PORT_C].enr = &(RCC->APB2ENR);
 	portHandlesStatic[RCC_PORT_C].enable = RCC_APB2ENR_IOPCEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOCEN
+	portHandlesStatic[RCC_PORT_C].exists = true;
+	portHandlesStatic[RCC_PORT_C].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_C].enable = RCC_AHB2ENR_GPIOCEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIODEN
@@ -84,6 +96,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_D].exists = true;
 	portHandlesStatic[RCC_PORT_D].enr = &(RCC->APB2ENR);
 	portHandlesStatic[RCC_PORT_D].enable = RCC_APB2ENR_IOPDEN_Pos;
+#elif defined RCC_AHB2ENR_GPIODEN
+	portHandlesStatic[RCC_PORT_D].exists = true;
+	portHandlesStatic[RCC_PORT_D].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_D].enable = RCC_AHB2ENR_GPIODEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOEEN
@@ -98,6 +114,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_E].exists = true;
 	portHandlesStatic[RCC_PORT_E].enr = &(RCC->APB2ENR);
 	portHandlesStatic[RCC_PORT_E].enable = RCC_APB2ENR_IOPEEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOeEN
+	portHandlesStatic[RCC_PORT_E].exists = true;
+	portHandlesStatic[RCC_PORT_E].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_E].enable = RCC_AHB2ENR_GPIOEEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOFEN
@@ -108,6 +128,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_F].exists = true;
 	portHandlesStatic[RCC_PORT_F].enr = &(RCC->AHB1ENR);
 	portHandlesStatic[RCC_PORT_F].enable = RCC_AHB1ENR_GPIOFEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOFEN
+	portHandlesStatic[RCC_PORT_F].exists = true;
+	portHandlesStatic[RCC_PORT_F].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_F].enable = RCC_AHB2ENR_GPIOFEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOGEN
@@ -118,6 +142,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_G].exists = true;
 	portHandlesStatic[RCC_PORT_G].enr = &(RCC->AHB1ENR);
 	portHandlesStatic[RCC_PORT_G].enable = RCC_AHB1ENR_GPIOGEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOGEN
+	portHandlesStatic[RCC_PORT_G].exists = true;
+	portHandlesStatic[RCC_PORT_G].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_G].enable = RCC_AHB2ENR_GPIOGEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOHEN
@@ -128,6 +156,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_H].exists = true;
 	portHandlesStatic[RCC_PORT_H].enr = &(RCC->AHB1ENR);
 	portHandlesStatic[RCC_PORT_H].enable = RCC_AHB1ENR_GPIOHEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOHEN
+	portHandlesStatic[RCC_PORT_H].exists = true;
+	portHandlesStatic[RCC_PORT_H].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_H].enable = RCC_AHB2ENR_GPIOHEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOIEN
@@ -138,6 +170,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_I].exists = true;
 	portHandlesStatic[RCC_PORT_I].enr = &(RCC->AHB1ENR);
 	portHandlesStatic[RCC_PORT_I].enable = RCC_AHB1ENR_GPIOIEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOIEN
+	portHandlesStatic[RCC_PORT_I].exists = true;
+	portHandlesStatic[RCC_PORT_I].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_I].enable = RCC_AHB2ENR_GPIOIEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOJEN
@@ -148,6 +184,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_J].exists = true;
 	portHandlesStatic[RCC_PORT_J].enr = &(RCC->AHB1ENR);
 	portHandlesStatic[RCC_PORT_J].enable = RCC_AHB1ENR_GPIOJEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOJEN
+	portHandlesStatic[RCC_PORT_J].exists = true;
+	portHandlesStatic[RCC_PORT_J].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_J].enable = RCC_AHB2ENR_GPIOJEN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_GPIOKEN
@@ -158,6 +198,10 @@ RccPortHandle* portHandles() {
 	portHandlesStatic[RCC_PORT_K].exists = true;
 	portHandlesStatic[RCC_PORT_K].enr = &(RCC->AHB1ENR);
 	portHandlesStatic[RCC_PORT_K].enable = RCC_AHB1ENR_GPIOKEN_Pos;
+#elif defined RCC_AHB2ENR_GPIOKEN
+	portHandlesStatic[RCC_PORT_K].exists = true;
+	portHandlesStatic[RCC_PORT_K].enr = &(RCC->AHB2ENR);
+	portHandlesStatic[RCC_PORT_K].enable = RCC_AHB2ENR_GPIOKEN_Pos;
 #endif
 	
 	return portHandlesStatic;
@@ -208,6 +252,10 @@ RccPeripheralHandle* peripheralHandles() {
 	peripheralHandlesStatic[RCC_DMA2].exists = true;
 	peripheralHandlesStatic[RCC_DMA2].enr = &(RCC->AHBENR);
 	peripheralHandlesStatic[RCC_DMA2].enable = RCC_AHBENR_DMA2EN_Pos;
+#elif defined RCC_AHB1ENR_DMA2EN
+	peripheralHandlesStatic[RCC_DMA2].exists = true;
+	peripheralHandlesStatic[RCC_DMA2].enr = &(RCC->AHB1ENR);
+	peripheralHandlesStatic[RCC_DMA2].enable = RCC_AHB1ENR_DMA2EN_Pos;
 #endif
 
 #ifdef RCC_AHBENR_DMAEN
@@ -264,6 +312,10 @@ RccPeripheralHandle* peripheralHandles() {
 	peripheralHandlesStatic[RCC_ADC1].exists = true;
 	peripheralHandlesStatic[RCC_ADC1].enr = &(RCC->APB2ENR);
 	peripheralHandlesStatic[RCC_ADC1].enable = RCC_APB2ENR_ADC1EN_Pos;
+#elif defined RCC_AHB2ENR_ADCEN
+	peripheralHandlesStatic[RCC_ADC1].exists = true;
+	peripheralHandlesStatic[RCC_ADC1].enr = &(RCC->AHB2ENR);
+	peripheralHandlesStatic[RCC_ADC1].enable = RCC_AHB2ENR_ADCEN_Pos;
 #endif
 
 #ifdef RCC_APB2ENR_ADC2EN
@@ -332,24 +384,40 @@ RccPeripheralHandle* peripheralHandles() {
 	peripheralHandlesStatic[RCC_TIM2].exists = true;
 	peripheralHandlesStatic[RCC_TIM2].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_TIM2].enable = RCC_APB1ENR_TIM2EN_Pos;
+#elif defined RCC_APB1ENR1_TIM2EN
+	peripheralHandlesStatic[RCC_TIM2].exists = true;
+	peripheralHandlesStatic[RCC_TIM2].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_TIM2].enable = RCC_APB1ENR1_TIM2EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_TIM3EN
 	peripheralHandlesStatic[RCC_TIM3].exists = true;
 	peripheralHandlesStatic[RCC_TIM3].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_TIM3].enable = RCC_APB1ENR_TIM3EN_Pos;
+#elif defined RCC_APB1ENR1_TIM3EN
+	peripheralHandlesStatic[RCC_TIM3].exists = true;
+	peripheralHandlesStatic[RCC_TIM3].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_TIM3].enable = RCC_APB1ENR1_TIM3EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_TIM6EN
 	peripheralHandlesStatic[RCC_TIM6].exists = true;
 	peripheralHandlesStatic[RCC_TIM6].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_TIM6].enable = RCC_APB1ENR_TIM6EN_Pos;
+#elif defined RCC_APB1ENR1_TIM6EN
+	peripheralHandlesStatic[RCC_TIM6].exists = true;
+	peripheralHandlesStatic[RCC_TIM6].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_TIM6].enable = RCC_APB1ENR1_TIM6EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_TIM7EN
 	peripheralHandlesStatic[RCC_TIM7].exists = true;
 	peripheralHandlesStatic[RCC_TIM7].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_TIM7].enable = RCC_APB1ENR_TIM7EN_Pos;
+#elif defined RCC_APB1ENR1_TIM7EN
+	peripheralHandlesStatic[RCC_TIM7].exists = true;
+	peripheralHandlesStatic[RCC_TIM7].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_TIM7].enable = RCC_APB1ENR1_TIM7EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_TIM14EN
@@ -374,18 +442,30 @@ RccPeripheralHandle* peripheralHandles() {
 	peripheralHandlesStatic[RCC_USART2].exists = true;
 	peripheralHandlesStatic[RCC_USART2].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_USART2].enable = RCC_APB1ENR_USART2EN_Pos;
+#elif defined RCC_APB1ENR1_USART2EN
+	peripheralHandlesStatic[RCC_USART2].exists = true;
+	peripheralHandlesStatic[RCC_USART2].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_USART2].enable = RCC_APB1ENR1_USART2EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_USART3EN
 	peripheralHandlesStatic[RCC_USART3].exists = true;
 	peripheralHandlesStatic[RCC_USART3].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_USART3].enable = RCC_APB1ENR_USART3EN_Pos;
+#elif defined RCC_APB1ENR1_USART3EN
+	peripheralHandlesStatic[RCC_USART3].exists = true;
+	peripheralHandlesStatic[RCC_USART3].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_USART3].enable = RCC_APB1ENR1_USART3EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_USART4EN
 	peripheralHandlesStatic[RCC_USART4].exists = true;
 	peripheralHandlesStatic[RCC_USART4].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_USART4].enable = RCC_APB1ENR_USART4EN_Pos;
+#elif defined RCC_APB1ENR1_USART4EN
+	peripheralHandlesStatic[RCC_USART4].exists = true;
+	peripheralHandlesStatic[RCC_USART4].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_USART4].enable = RCC_APB1ENR1_USART4EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_USART5EN
@@ -410,42 +490,70 @@ RccPeripheralHandle* peripheralHandles() {
 	peripheralHandlesStatic[RCC_I2C1].exists = true;
 	peripheralHandlesStatic[RCC_I2C1].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_I2C1].enable = RCC_APB1ENR_I2C1EN_Pos;
+#elif defined RCC_APB1ENR1_I2C1EN
+	peripheralHandlesStatic[RCC_I2C1].exists = true;
+	peripheralHandlesStatic[RCC_I2C1].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_I2C1].enable = RCC_APB1ENR1_I2C1EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_I2C2EN
 	peripheralHandlesStatic[RCC_I2C2].exists = true;
 	peripheralHandlesStatic[RCC_I2C2].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_I2C2].enable = RCC_APB1ENR_I2C2EN_Pos;
+#elif defined RCC_APB1ENR1_I2C2EN
+	peripheralHandlesStatic[RCC_I2C2].exists = true;
+	peripheralHandlesStatic[RCC_I2C2].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_I2C2].enable = RCC_APB1ENR1_I2C2EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_USBEN
 	peripheralHandlesStatic[RCC_USB].exists = true;
 	peripheralHandlesStatic[RCC_USB].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_USB].enable = RCC_APB1ENR_USBEN_Pos;
+#elif defined RCC_APB1ENR1_USBFSEN
+	peripheralHandlesStatic[RCC_USB].exists = true;
+	peripheralHandlesStatic[RCC_USB].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_USB].enable = RCC_APB1ENR1_USBFSEN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_CANEN
 	peripheralHandlesStatic[RCC_CAN].exists = true;
 	peripheralHandlesStatic[RCC_CAN].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_CAN].enable = RCC_APB1ENR_CANEN_Pos;
+#elif defined RCC_APB1ENR1_CAN1EN
+	peripheralHandlesStatic[RCC_CAN].exists = true;
+	peripheralHandlesStatic[RCC_CAN].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_CAN].enable = RCC_APB1ENR1_CAN1EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_CRSEN
 	peripheralHandlesStatic[RCC_CRS].exists = true;
 	peripheralHandlesStatic[RCC_CRS].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_CRS].enable = RCC_APB1ENR_CRSEN_Pos;
+#elif defined RCC_APB1ENR1_CRSEN
+	peripheralHandlesStatic[RCC_CRS].exists = true;
+	peripheralHandlesStatic[RCC_CRS].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_CRS].enable = RCC_APB1ENR1_CRSEN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_PWREN
 	peripheralHandlesStatic[RCC_PWR].exists = true;
 	peripheralHandlesStatic[RCC_PWR].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_PWR].enable = RCC_APB1ENR_PWREN_Pos;
+#elif defined RCC_APB1ENR1_PWREN
+	peripheralHandlesStatic[RCC_PWR].exists = true;
+	peripheralHandlesStatic[RCC_PWR].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_PWR].enable = RCC_APB1ENR1_PWREN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_DACEN
 	peripheralHandlesStatic[RCC_DAC].exists = true;
 	peripheralHandlesStatic[RCC_DAC].enr = &(RCC->APB1ENR);
 	peripheralHandlesStatic[RCC_DAC].enable = RCC_APB1ENR_DACEN_Pos;
+#elif defined RCC_APB1ENR1_DAC1EN
+	peripheralHandlesStatic[RCC_DAC].exists = true;
+	peripheralHandlesStatic[RCC_DAC].enr = &(RCC->APB1ENR1);
+	peripheralHandlesStatic[RCC_DAC].enable = RCC_APB1ENR1_DAC1EN_Pos;
 #endif
 
 #ifdef RCC_APB1ENR_CECEN

--- a/arch/stm32/cpp/core/src/usart.cpp
+++ b/arch/stm32/cpp/core/src/usart.cpp
@@ -28,6 +28,9 @@ USART_device* USART_list() {
 #if defined RCC_APB1ENR_USART2EN
 	devicesStatic[USART_2].regs = USART2;
 	devicesStatic[USART_2].irqType = USART2_IRQn;
+#elif defined RCC_APB1ENR1_USART2EN
+	devicesStatic[USART_2].regs = USART2;
+	devicesStatic[USART_2].irqType = USART2_IRQn;
 #endif
 
 #if defined RCC_APB1ENR_USART3EN
@@ -38,6 +41,9 @@ USART_device* USART_list() {
 	devicesStatic[USART_3].regs = USART3;
 	devicesStatic[USART_3].irqType = USART3_IRQn;
 #endif
+#elif defined RCC_APB1ENR1_USART3EN
+	devicesStatic[USART_2].regs = USART3;
+	devicesStatic[USART_2].irqType = USART3_IRQn;
 #endif
 
 #if defined RCC_APB1ENR_UART4EN
@@ -48,6 +54,9 @@ USART_device* USART_list() {
 	devicesStatic[USART_4].regs = UART4;
 	devicesStatic[USART_4].irqType = UART4_IRQn;
 #endif
+#elif defined RCC_APB1ENR1_UART4EN
+	devicesStatic[USART_2].regs = UART4;
+	devicesStatic[USART_2].irqType = UART4_IRQn;
 #endif
 
 #if defined RCC_APB1ENR_UART5EN
@@ -82,7 +91,13 @@ GPIO USART::gpio;
 
 // Callback handlers.
 // Overrides the default handlers and allows the use of custom callback functions.
-#if defined __stm32f1 || defined __stm32f4 || defined __stm32f7
+#if defined __stm32f0
+extern "C" {
+	void USART1_IRQHandler(void);
+	void USART2_IRQHandler(void);
+	void USART3_4_IRQHandler(void);
+}
+#else
 extern "C" {
 	void USART1_IRQHandler(void);
 	void USART2_IRQHandler(void);
@@ -92,12 +107,6 @@ extern "C" {
 	void USART6_IRQHandler(void);
 	void USART7_IRQHandler(void);
 	void USART8_IRQHandler(void);
-}
-#elif defined __stm32f0
-extern "C" {
-	void USART1_IRQHandler(void);
-	void USART2_IRQHandler(void);
-	void USART3_4_IRQHandler(void);
 }
 #endif
 
@@ -131,72 +140,6 @@ void USART3_4_IRQHandler(void) {
 	else if (instance2.regs->ISR & USART_ISR_RXNE) {
 		rxb = instance2.regs->RDR;
 		instance2.callback(rxb);
-	}
-}
-
-#elif defined __stm32f7
-
-void USART1_IRQHandler(void) {
-	USART_device &instance = devicesStatic[0];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
-	}
-}
-
-void USART2_IRQHandler(void) {
-	USART_device &instance = devicesStatic[1];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
-	}
-}
-
-void USART3_IRQHandler(void) {
-	USART_device &instance = devicesStatic[2];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
-	}
-}
-
-void USART4_IRQHandler(void) {
-	USART_device &instance = devicesStatic[3];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
-	}
-}
-
-void USART5_IRQHandler(void) {
-	USART_device &instance = devicesStatic[4];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
-	}
-}
-
-void USART6_IRQHandler(void) {
-	USART_device &instance = devicesStatic[5];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
-	}
-}
-
-void USART7_IRQHandler(void) {
-	USART_device &instance = devicesStatic[6];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
-	}
-}
-
-void USART8_IRQHandler(void) {
-	USART_device &instance = devicesStatic[7];
-	if (instance.regs->ISR & USART_ISR_RXNE) {
-		rxb = instance.regs->RDR;
-		instance.callback(rxb);
 	}
 }
 
@@ -262,6 +205,73 @@ void USART8_IRQHandler(void) {
 	USART_device &instance = devicesStatic[7];
 	if (instance.regs->SR & USART_SR_RXNE) {
 		rxb = instance.regs->DR;
+		instance.callback(rxb);
+	}
+}
+
+
+#else
+
+void USART1_IRQHandler(void) {
+	USART_device &instance = devicesStatic[0];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
+		instance.callback(rxb);
+	}
+}
+
+void USART2_IRQHandler(void) {
+	USART_device &instance = devicesStatic[1];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
+		instance.callback(rxb);
+	}
+}
+
+void USART3_IRQHandler(void) {
+	USART_device &instance = devicesStatic[2];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
+		instance.callback(rxb);
+	}
+}
+
+void USART4_IRQHandler(void) {
+	USART_device &instance = devicesStatic[3];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
+		instance.callback(rxb);
+	}
+}
+
+void USART5_IRQHandler(void) {
+	USART_device &instance = devicesStatic[4];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
+		instance.callback(rxb);
+	}
+}
+
+void USART6_IRQHandler(void) {
+	USART_device &instance = devicesStatic[5];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
+		instance.callback(rxb);
+	}
+}
+
+void USART7_IRQHandler(void) {
+	USART_device &instance = devicesStatic[6];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
+		instance.callback(rxb);
+	}
+}
+
+void USART8_IRQHandler(void) {
+	USART_device &instance = devicesStatic[7];
+	if (instance.regs->ISR & USART_ISR_RXNE) {
+		rxb = instance.regs->RDR;
 		instance.callback(rxb);
 	}
 }
@@ -351,7 +361,7 @@ bool USART::startUart(USART_devices device, GPIO_ports tx_port, uint8_t tx_pin, 
 	uint32_t usartClock = SystemCoreClock >> tmp;
 	uint16_t uartdiv = usartClock / baudrate;
 	
-#if defined __stm32f0 || defined __stm32f7
+#if defined __stm32f0 || defined __stm32f7 || defined __stm32l4
 	instance.regs->BRR = (((uartdiv / 16) << USART_BRR_DIV_MANTISSA_Pos) |
 							((uartdiv % 16) << USART_BRR_DIV_FRACTION_Pos));
 #elif defined __stm32f4 || defined __stm32f1
@@ -388,7 +398,7 @@ bool USART::sendUart(USART_devices device, char &ch) {
 	if (!instance.active) { return false; }
 	
 	// Copy bit to the device's transmission register.
-#if defined __stm32f0 || defined __stm32f7
+#if defined __stm32f0 || defined __stm32f7 || defined __stm32l4
 	while (!(instance.regs->ISR & USART_ISR_TXE)) {};
 	instance.regs->TDR = (uint8_t) ch;
 #elif defined __stm32f4

--- a/arch/stm32/cpp/libs/bme280/bme280.cpp
+++ b/arch/stm32/cpp/libs/bme280/bme280.cpp
@@ -47,10 +47,13 @@ bool BME280::readID(uint8_t &id) {
 	// Read the response once it comes in.
 	uint32_t to = 1000000;
 	while (I2C_wait && to > 1) {
-		// TODO: elegantly handle timeout.
 		to--;
 	}
-	
+	if (to == 1) {
+		// we reached this via a time-out
+		return false;
+	}
+
 	id = I2C_byte;
 	
 	return true;


### PR DESCRIPTION
This pull request adds code to set the I2C timing register based on the default clock source applicable for the I2C peripheral being used.

Other I2C changes include:
- added support for STM32F1 and STM32F4 (the bulk of the added code)
- adding support for STM32F7
- adding support for STM32L4
- added usart support for STM32L4 to support testing
